### PR TITLE
Fix auto-paging next page length check

### DIFF
--- a/internal/shared/pagination.go
+++ b/internal/shared/pagination.go
@@ -76,7 +76,7 @@ func (r *PageAutoPager[T]) Next() bool {
 	if r.idx >= len(r.page.Items) {
 		r.idx = 0
 		r.page, r.err = r.page.GetNextPage()
-		if r.err != nil || r.page == nil {
+		if r.err != nil || r.page == nil || len(r.page.Items) == 0 {
 			return false
 		}
 	}


### PR DESCRIPTION
Without this, we're not correctly checking the next page before trying to access it to set the "current" item which leads to an out of bounds issue as we're accessing the zero index of an empty slice.

Here's an example test we wrote to surface this issue:
```go
func TestListLedgerAccountsAutoPage(t *testing.T) {
	fmt.Printf("STARTING TEST\n")

	var ledgerAccs []string
	iter := client.LedgerAccounts.ListAutoPaging(ctx,
		mt.LedgerAccountListParams{
			LedgerID: mt.F(LedgerID),
			PerPage:  mt.F(int64(10)),
		},
	)
	count := 0
	for {
		count++
		hasNext := iter.Next()
		fmt.Printf("iter count: %v, hasNext: %v\n", count, hasNext)
		if !hasNext {
			break
		}
		curr := iter.Current()
		ledgerAccs = append(ledgerAccs, fmt.Sprintf("Account ID: %s, Name: %s", curr.ID, curr.Name))
	}
	if err := iter.Err(); err != nil {
		t.Fatal(err)
	}
	fmt.Printf("%d RESULTS:\n", len(ledgerAccs))
	for _, acc := range ledgerAccs {
		fmt.Printf("%s\n", acc)
	}
}
```

In this case, the sandbox Ledger use here had only 16 items in total and these are the results of running the test:
```
STARTING TEST
iter count: 1, hasNext: true
iter count: 2, hasNext: true
iter count: 3, hasNext: true
iter count: 4, hasNext: true
iter count: 5, hasNext: true
iter count: 6, hasNext: true
iter count: 7, hasNext: true
iter count: 8, hasNext: true
iter count: 9, hasNext: true
iter count: 10, hasNext: true
iter count: 11, hasNext: true
iter count: 12, hasNext: true
iter count: 13, hasNext: true
iter count: 14, hasNext: true
iter count: 15, hasNext: true
iter count: 16, hasNext: true
--- FAIL: TestListLedgerAccountsAutoPage (0.65s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0
```

Fixes https://github.com/Modern-Treasury/modern-treasury-go/pull/93