### PR TITLE
Add sync-processing fields to partial post posted_ledger_entries

### DIFF
--- a/ledgertransaction.go
+++ b/ledgertransaction.go
@@ -533,9 +533,29 @@ type LedgerTransactionNewPartialPostParamsPostedLedgerEntry struct {
 	Direction param.Field[LedgerTransactionNewPartialPostParamsPostedLedgerEntriesDirection] `json:"direction" api:"required"`
 	// The ledger account that this ledger entry is associated with.
 	LedgerAccountID param.Field[string] `json:"ledger_account_id" api:"required" format:"uuid"`
+	// Use `gt` (>), `gte` (>=), `lt` (<), `lte` (<=), or `eq` (=) to lock on the
+	// account’s available balance. If any of these conditions would be false after the
+	// transaction is created, the entire call will fail with error code 422.
+	AvailableBalanceAmount param.Field[map[string]int64] `json:"available_balance_amount"`
+	// Lock version of the ledger account. This can be passed when creating a ledger
+	// transaction to only succeed if no ledger transactions have posted since the
+	// given version. See our post about Designing the Ledgers API with Optimistic
+	// Locking for more details.
+	LockVersion param.Field[int64] `json:"lock_version"`
 	// Additional data represented as key-value pairs. Both the key and value must be
 	// strings.
 	Metadata param.Field[map[string]string] `json:"metadata"`
+	// Use `gt` (>), `gte` (>=), `lt` (<), `lte` (<=), or `eq` (=) to lock on the
+	// account’s pending balance. If any of these conditions would be false after the
+	// transaction is created, the entire call will fail with error code 422.
+	PendingBalanceAmount param.Field[map[string]int64] `json:"pending_balance_amount"`
+	// Use `gt` (>), `gte` (>=), `lt` (<), `lte` (<=), or `eq` (=) to lock on the
+	// account’s posted balance. If any of these conditions would be false after the
+	// transaction is created, the entire call will fail with error code 422.
+	PostedBalanceAmount param.Field[map[string]int64] `json:"posted_balance_amount"`
+	// If true, response will include the balance of the associated ledger account for
+	// the entry.
+	ShowResultingLedgerAccountBalances param.Field[bool] `json:"show_resulting_ledger_account_balances"`
 }
 
 func (r LedgerTransactionNewPartialPostParamsPostedLedgerEntry) MarshalJSON() (data []byte, err error) {

--- a/ledgertransaction_test.go
+++ b/ledgertransaction_test.go
@@ -243,11 +243,22 @@ func TestLedgerTransactionNewPartialPostWithOptionalParams(t *testing.T) {
 				Amount:          moderntreasury.F(int64(0)),
 				Direction:       moderntreasury.F(moderntreasury.LedgerTransactionNewPartialPostParamsPostedLedgerEntriesDirectionCredit),
 				LedgerAccountID: moderntreasury.F("182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e"),
+				AvailableBalanceAmount: moderntreasury.F(map[string]int64{
+					"foo": int64(0),
+				}),
+				LockVersion: moderntreasury.F(int64(0)),
 				Metadata: moderntreasury.F(map[string]string{
 					"key":    "value",
 					"foo":    "bar",
 					"modern": "treasury",
 				}),
+				PendingBalanceAmount: moderntreasury.F(map[string]int64{
+					"foo": int64(0),
+				}),
+				PostedBalanceAmount: moderntreasury.F(map[string]int64{
+					"foo": int64(0),
+				}),
+				ShowResultingLedgerAccountBalances: moderntreasury.F(true),
 			}}),
 			Description: moderntreasury.F("description"),
 			EffectiveAt: moderntreasury.F(time.Now()),


### PR DESCRIPTION
## Summary

Mirrors [Modern-Treasury/docs-readme-platform#67](https://github.com/Modern-Treasury/docs-readme-platform/pull/67) in the Go SDK, exposing the synchronous-processing fields supported by [`POST /ledger_transactions/{id}/partial_post`](https://docs.moderntreasury.com/platform/reference/create-ledger-transaction-partial-post) on each item of `posted_ledger_entries`:

- `LockVersion`
- `PendingBalanceAmount`
- `PostedBalanceAmount`
- `AvailableBalanceAmount`
- `ShowResultingLedgerAccountBalances`

Fields, JSON tags, and descriptions follow the existing `shared.LedgerEntryCreateRequestParam` shape used by `POST /ledger_transactions`. The test for `LedgerTransactions.NewPartialPost` is updated to set each new optional field, matching the pattern in `TestLedgerTransactionNewWithOptionalParams`.

## Review & Testing Checklist for Human

- [ ] Confirm the new fields and their JSON tags match what the partial-post endpoint actually accepts (cross-check against the OpenAPI spec / `docs-readme-platform#67`).
- [ ] Confirm `archive_on_balance_lock_failure` is intentionally NOT exposed at the top-level params (matches the docs PR decision).
- [ ] Verify the SDK regenerator is OK with this manual patch (CONTRIBUTING.md notes manual edits persist across regenerations but can conflict).

### Notes

- This is a manual patch to generated code; the next OpenAPI/SDK sync should preserve it but may reformat the field ordering.
- No changes to the partial post response shape — only request params.


Link to Devin session: https://app.devin.ai/sessions/d2f47abd8b144872a3a6f0914c38ccd9
Requested by: @hanlinc27