### PR TITLE
fix(apiquery): encode float32 query values at float32 precision

### DIFF
--- a/internal/apiquery/encoder.go
+++ b/internal/apiquery/encoder.go
@@ -285,7 +285,11 @@ func (e *encoder) newPrimitiveTypeEncoder(t reflect.Type) encoderFunc {
 		return func(key string, v reflect.Value) []Pair {
 			return []Pair{{key, strconv.FormatUint(v.Uint(), 10)}}
 		}
-	case reflect.Float32, reflect.Float64:
+	case reflect.Float32:
+		return func(key string, v reflect.Value) []Pair {
+			return []Pair{{key, strconv.FormatFloat(v.Float(), 'f', -1, 32)}}
+		}
+	case reflect.Float64:
 		return func(key string, v reflect.Value) []Pair {
 			return []Pair{{key, strconv.FormatFloat(v.Float(), 'f', -1, 64)}}
 		}

--- a/internal/apiquery/query_test.go
+++ b/internal/apiquery/query_test.go
@@ -107,13 +107,13 @@ var tests = map[string]struct {
 	settings QuerySettings
 }{
 	"primitives": {
-		"a=false&b=237628372683&c=654&d=9999.43&e=43.7599983215332&f=1,2,3,4",
+		"a=false&b=237628372683&c=654&d=9999.43&e=43.76&f=1,2,3,4",
 		Primitives{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
 		QuerySettings{},
 	},
 
 	"slices_brackets": {
-		`mixed[]=1&mixed[]=2.3&mixed[]=hello&slices[][a]=false&slices[][a]=false&slices[][b]=237628372683&slices[][b]=237628372683&slices[][c]=654&slices[][c]=654&slices[][d]=9999.43&slices[][d]=9999.43&slices[][e]=43.7599983215332&slices[][e]=43.7599983215332&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4`,
+		`mixed[]=1&mixed[]=2.3&mixed[]=hello&slices[][a]=false&slices[][a]=false&slices[][b]=237628372683&slices[][b]=237628372683&slices[][c]=654&slices[][c]=654&slices[][d]=9999.43&slices[][d]=9999.43&slices[][e]=43.76&slices[][e]=43.76&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4`,
 		Slices{
 			Slice: []Primitives{
 				{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
@@ -133,7 +133,7 @@ var tests = map[string]struct {
 	},
 
 	"slices_repeat": {
-		`mixed=1&mixed=2.3&mixed=hello&slices[a]=false&slices[a]=false&slices[b]=237628372683&slices[b]=237628372683&slices[c]=654&slices[c]=654&slices[d]=9999.43&slices[d]=9999.43&slices[e]=43.7599983215332&slices[e]=43.7599983215332&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4`,
+		`mixed=1&mixed=2.3&mixed=hello&slices[a]=false&slices[a]=false&slices[b]=237628372683&slices[b]=237628372683&slices[c]=654&slices[c]=654&slices[d]=9999.43&slices[d]=9999.43&slices[e]=43.76&slices[e]=43.76&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4`,
 		Slices{
 			Slice: []Primitives{
 				{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
@@ -145,7 +145,7 @@ var tests = map[string]struct {
 	},
 
 	"primitive_pointer_struct": {
-		"a=false&b=237628372683&c=654&d=9999.43&e=43.7599983215332&f=1,2,3,4,5",
+		"a=false&b=237628372683&c=654&d=9999.43&e=43.76&f=1,2,3,4,5",
 		PrimitivePointers{
 			A: P(false),
 			B: P(237628372683),


### PR DESCRIPTION
Encode Float32 query values at bit size 32. Fix + tests updated, verified locally.